### PR TITLE
Add Japanese translation

### DIFF
--- a/ChestCleaner_2-4-3_ja_JP.properties
+++ b/ChestCleaner_2-4-3_ja_JP.properties
@@ -1,0 +1,47 @@
+# ChestCleaner.properties の日本語翻訳
+# ---------- 共通 ---------- #
+common.error = エラー
+common.error.syntax = 構文エラー
+common.page = ページ %s:
+common.page.next = 次のエントリのために: リスト %s"
+common.prefix = §6[ChestCleaner]
+# ---------- エラー ---------- #
+error.blacklist.empty = ブラックリストは空です。
+error.blacklist.exists = 素材 %s は既にブラックリストにあります。
+error.blacklist.inventory = このインベントリはブラックリストにあります。ソートできません。
+error.blacklist.not.exists = ブラックリストに素材 \"%s\" は含まれていません。
+error.blacklist.list.not.exist = このブラックリストは存在しません。
+error.block.no.inventory = 位置 %s のブロックにはインベントリがありません。
+error.category.book = 本を解析できませんでした。
+error.category.name = この名前のカテゴリは存在しません。
+error.category.notinconfig = カテゴリ §b%s§a は config.yml に保存されていません。削除できません。
+error.category.invalid = ソート設定に無効なカテゴリがあります。
+error.material.name = この名前の素材 \"%s\" は存在しません。
+error.page.number = 無効なページ番号 (有効なページ番号範囲: %s)。
+error.pattern.id = このIDのパターンは存在しません。
+error.permission = 申し訳ありませんが、このコマンドを実行する権限がありません。
+error.player.not.online = プレイヤー %s はオンラインではありません。
+error.sound.notfound = 名前 %s のサウンドは存在しません。
+error.validation.bool = 値は true または false でなければなりません。
+error.validation.index.bounds = インデックスが範囲外です。-1 より大きく、%s より小さくなければなりません。
+error.validation.integer = 整数の無効な入力: "%s"。
+error.world.name = この名前のワールド \"%s\" は存在しません。
+error.you.cooldown.sorting = 次のインベントリをソートするには %s 秒待つ必要があります。
+error.you.cooldown.generic = これを行うことはできません。%s 待って再試行してください。
+error.you.hold.item = これを行うにはアイテムを持っている必要があります。
+error.you.not.player = このコマンドを実行するにはプレイヤーである必要があります。
+# ---------- 情報 ---------- #
+info.blacklist.add = 素材 \"%s\" がブラックリストに追加されました。
+info.blacklist.cleared = ブラックリストが正常にクリアされました。
+info.blacklist.del = 素材 \"%s\" がブラックリストから削除されました。
+info.category.new = 新しいカテゴリが追加されました: %s
+info.category.removed = カテゴリ §b%s§a が削除されました。
+info.category.reseted = カテゴリ設定がサーバーのデフォルトにリセットされました。
+info.cleaningitem.player.get = プレイヤー %s がクリーニングアイテムを受け取りました。
+info.cleaningitem.you.get = クリーニングアイテムを受け取りました。
+info.inventory.sorted = インベントリがソートされました。
+info.sorting.sound.default.set = デフォルトのソートサウンドが %s に設定されました。
+info.update.available = 新しいアップデートが利用可能です:§b https://www.spigotmc.org/resources/40313/updates 。
+info.value.changed = §b%s§a の値が §d%s§a に設定されました。
+info.value.current = §b%s§a の現在の値は: §d%s
+info.config.reset = 設定がリセットされました。


### PR DESCRIPTION
Fixes #1

Adds Japanese translation to the ChestCleaner plugin.

* **New Translation File**: Adds `ChestCleaner_2-4-3_ja_JP.properties` with translations for common messages, error messages, and information messages.
* **Common Messages**: Translates common messages such as errors, page navigation, and prefixes.
* **Error Messages**: Translates various error messages related to blacklist, inventory, categories, materials, permissions, players, sounds, validation, and world names.
* **Information Messages**: Translates information messages related to blacklist management, category management, cleaning items, inventory sorting, sorting sounds, updates, value changes, and configuration reset.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/narumincho/ChestCleaner/pull/2?shareId=62a08411-17b6-4b82-a93f-1f6ba0b8ed92).